### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/markets_controller.rb
+++ b/app/controllers/markets_controller.rb
@@ -2,6 +2,7 @@ class MarketsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   
   def index
+    @items = Item.all
   end
 
   def new

--- a/app/controllers/markets_controller.rb
+++ b/app/controllers/markets_controller.rb
@@ -2,7 +2,7 @@ class MarketsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   
   def index
-    @items = Item.all
+    @items = Item.all.order(id: :DESC)
   end
 
   def new

--- a/app/views/markets/index.html.erb
+++ b/app/views/markets/index.html.erb
@@ -123,7 +123,7 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_market_path, class: "subtitle" %>
     <ul class='item-lists'>
     
         <% @items.each do |item| %>

--- a/app/views/markets/index.html.erb
+++ b/app/views/markets/index.html.erb
@@ -145,7 +145,7 @@
                 <%= item.name %>
               </h3>
               <div class='item-price'>
-                <span><%= item.price %>円<br><%= item.shipping_cost_id %></span>
+                <span><%= item.price %>円<br><%= item.shipping_cost.name %></span>
                 <div class='star-btn'>
                   <%= image_tag "star.png", class:"star-icon" %>
                   <span class='star-count'>0</span>

--- a/app/views/markets/index.html.erb
+++ b/app/views/markets/index.html.erb
@@ -125,36 +125,37 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
+    
+        <% @items.each do |item| %>
+          <li class='list'>
+            <%= link_to markets_path do %>
+                <div class='item-img-content'>
+                  <%= image_tag item.image, class: "item-img" %>
+                  
 
-      <li class='list'>
-        <%= link_to markets_path do %>
-         <% @items.each do |item| %>
-            <div class='item-img-content'>
-              <%= image_tag item.image, class: "item-img" %>
-              
+                  <% if @item.present? %> 
+                    <div class='sold-out'>
+                      <span>Sold Out!!</span>
+                    </div>
+                  <% end %>
 
-              <% if @item.present? %> 
-                <div class='sold-out'>
-                  <span>Sold Out!!</span>
                 </div>
-              <% end %>
-
-            </div>
-            <div class='item-info'>
-              <h3 class='item-name'>
-                <%= item.name %>
-              </h3>
-              <div class='item-price'>
-                <span><%= item.price %>円<br><%= item.shipping_cost.name %></span>
-                <div class='star-btn'>
-                  <%= image_tag "star.png", class:"star-icon" %>
-                  <span class='star-count'>0</span>
+                <div class='item-info'>
+                  <h3 class='item-name'>
+                    <%= item.name %>
+                  </h3>
+                  <div class='item-price'>
+                    <span><%= item.price %>円<br><%= item.shipping_cost.name %></span>
+                    <div class='star-btn'>
+                      <%= image_tag "star.png", class:"star-icon" %>
+                      <span class='star-count'>0</span>
+                    </div>
+                  </div>
                 </div>
-              </div>
-            </div>
             <% end %>
-          <% end %>
-      </li>
+          </li>
+        <% end %>
+          
 
       <% if @items.length == 0 %>
       <li class='list'>

--- a/app/views/markets/index.html.erb
+++ b/app/views/markets/index.html.erb
@@ -156,9 +156,7 @@
           <% end %>
       </li>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <% if @item.present? %>
+      <% if @items.length == 0 %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -175,10 +173,8 @@
           </div>
         </div>
         <% end %>
-      </li>
+       </li>
       <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/markets/index.html.erb
+++ b/app/views/markets/index.html.erb
@@ -126,37 +126,39 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+        <%= link_to markets_path do %>
+         <% @items.each do |item| %>
+            <div class='item-img-content'>
+              <%= image_tag item.image, class: "item-img" %>
+              
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+              <% if @item.present? %> 
+                <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div>
+              <% end %>
 
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
             </div>
-          </div>
-        </div>
-        <% end %>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= item.name %>
+              </h3>
+              <div class='item-price'>
+                <span><%= item.price %>円<br><%= item.shipping_cost_id %></span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
+            </div>
+            <% end %>
+          <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @item.present? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -174,6 +176,7 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   
   devise_for :users
   root to:'markets#index'
-  resources :markets, only: [:new, :create] do
+  resources :markets, only: [ :index, :new, :create] do
   end
 
 end


### PR DESCRIPTION
## WHY

利用者にどんな商品があるのか分かりやすく見ていただくため。

## WHAT

投稿された商品がトップページに一覧表示されるように実装した。

一覧表示の様子
https://i.gyazo.com/de6149ba0d258bce4bb473a0fbdb50db.mp4
商品がない場合
https://i.gyazo.com/68456b814bfe3fe8bbc8e78ddb022974.mp4

商品がある場合
https://i.gyazo.com/7ada9367ef61bf4b0d563f4e7fd2d09b.mp4

送料が着払いか出品者負担なのか表示できるようにしました
https://i.gyazo.com/bf578427bcd114a2f47807bd5b7c0fff.mp4

投稿された商品を横並びで表示できるようにしました
https://i.gyazo.com/c787ee88707b322bba639c8f53e9b5a9.mp4