### PR TITLE
商品編集機能実装

### DIFF
--- a/app/controllers/markets_controller.rb
+++ b/app/controllers/markets_controller.rb
@@ -1,6 +1,8 @@
 class MarketsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  
+  before_action :set_item, only: [:show, :edit, :update]
+  before_action :only_buyer, only: [:edit, :update]
+
   def index
     @items = Item.all.order(id: :DESC)
   end
@@ -19,17 +21,12 @@ class MarketsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
-    redirect_to root_path unless current_user.id == @item.user_id
-
   end
 
   def update
-       @item = Item.find(params[:id])
     if @item.update(item_params)
        redirect_to root_path
     else
@@ -39,5 +36,13 @@ class MarketsController < ApplicationController
   private
   def item_params
     params.require(:item).permit(:name, :description, :category_id, :status_id, :shipping_cost_id, :shipping_area_id, :shipping_day_id, :price, :image).merge(user_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
+  end
+
+  def only_buyer
+    redirect_to root_path unless current_user.id == @item.user_id
   end
 end 

--- a/app/controllers/markets_controller.rb
+++ b/app/controllers/markets_controller.rb
@@ -33,7 +33,6 @@ class MarketsController < ApplicationController
     else
        render:edit
     end
-
   end
   private
   def item_params

--- a/app/controllers/markets_controller.rb
+++ b/app/controllers/markets_controller.rb
@@ -33,6 +33,14 @@ class MarketsController < ApplicationController
        render:edit
     end
   end
+
+  #def destroy
+    #if @prototype.destroy
+     # redirect_to root_path
+  #else
+     # redirect_to root_path
+    #end
+  ##end
   private
   def item_params
     params.require(:item).permit(:name, :description, :category_id, :status_id, :shipping_cost_id, :shipping_area_id, :shipping_day_id, :price, :image).merge(user_id: current_user.id)

--- a/app/controllers/markets_controller.rb
+++ b/app/controllers/markets_controller.rb
@@ -22,10 +22,19 @@ class MarketsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
-  #def edit
-  #end
+  def edit
+    @item = Item.find(params[:id])
+  end
 
+  def update
+       @item = Item.find(params[:id])
+    if @item.update(item_params)
+       redirect_to root_path
+    else
+       render:edit
+    end
 
+  end
   private
   def item_params
     params.require(:item).permit(:name, :description, :category_id, :status_id, :shipping_cost_id, :shipping_area_id, :shipping_day_id, :price, :image).merge(user_id: current_user.id)

--- a/app/controllers/markets_controller.rb
+++ b/app/controllers/markets_controller.rb
@@ -24,6 +24,8 @@ class MarketsController < ApplicationController
 
   def edit
     @item = Item.find(params[:id])
+    redirect_to root_path unless current_user.id == @item.user_id
+
   end
 
   def update

--- a/app/views/markets/edit.html.erb
+++ b/app/views/markets/edit.html.erb
@@ -3,15 +3,13 @@ app/assets/stylesheets/items/new.css %>
 
 <div class="items-sell-contents">
   <header class="items-sell-header">
-    <%= link_to image_tag('furima-logo-color.png' ,edit_market_path,  size: '185x50'), "/" %>
+    <%#= link_to image_tag('furima-logo-color.png' , '185x50'), "/" %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model: @item, local: true do |f| %>
+    <%= form_with model: @item, url: market_path, method: :patch, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <% render 'shared/error_messages', model: f.object %>
 
     <%# 出品画像 %>
     <div class="img-upload">
@@ -23,7 +21,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -33,13 +31,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +50,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :id, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [] , :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status, Status.all , :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +71,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [],:hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shippng_cost, ShippingCost.all,:id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:shipping_area, ShippingArea.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_day, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +99,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -140,8 +138,8 @@ app/assets/stylesheets/items/new.css %>
     <%# /注意書き %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
-      <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%= f.submit "変更する", class:"sell-btn" %>
+      <%=link_to 'もどる', market_path(@item.id), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/markets/edit.html.erb
+++ b/app/views/markets/edit.html.erb
@@ -9,8 +9,8 @@ app/assets/stylesheets/items/new.css %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, url: market_path, method: :patch, local: true do |f| %>
 
-    <% render 'shared/error_messages', model: f.object %>
-
+    <%= render 'shared/error_messages', model: f.object %>
+ 
     <%# 出品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">
@@ -50,12 +50,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:category, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select :category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"} %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:status, Status.all , :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select :status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"} %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -71,17 +71,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shippng_cost, ShippingCost.all,:id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select :shippng_cost_id, ShippingCost.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"} %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_area, ShippingArea.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select :shipping_area_id, ShippingArea.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"} %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_day, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select :shipping_day_id, ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"} %>
       </div>
     </div>
     <%# /配送について %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   
   devise_for :users
   root to:'markets#index'
-  resources :markets, only: [ :index, :new, :create, :show, :edit, :update, :destroy ] do
+  resources :markets, only: [ :index, :new, :create, :show, :edit, :update ] do
   end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   
   devise_for :users
   root to:'markets#index'
-  resources :markets, only: [ :index, :new, :create, :show, :edit, :destroy ] do
+  resources :markets, only: [ :index, :new, :create, :show, :edit, :update, :destroy ] do
   end
 
 end


### PR DESCRIPTION
### WHY
登録した商品を編集して、ユーザーのニーズに合った形で商品出品できるように

### WHAT
商品編集機能を実装しました。

ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://i.gyazo.com/bfc8263149cbe4ccf4e90a83b83213bb.mp4

正しく情報を記入すると、商品の情報を編集できる動画
https://i.gyazo.com/e6355dcb27d035629c1f1fb1e22ef1c6.mp4

入力に問題のある状態では商品の情報は編集できず、エラーメッセージが出力される動画
https://i.gyazo.com/6dbaf72f1cf2ad1b9af5158c73af7657.mp4

何も編集せずに更新をしても画像無しの商品にならない動画
https://i.gyazo.com/34cd1ec661b9bfcf10bcf446c74cb242.mp4

ログイン状態のユーザーであっても、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画
https://i.gyazo.com/77dbc740f6ffca251ab8504c778c2d0c.mp4

ログアウト状態のユーザーは、URLを直接入力して商品情報編集ページへ遷移しようとすると、ログインページに遷移する動画
https://i.gyazo.com/f96f7e82727b6402c52b240fff22a8d7.mp4

ログイン状態の出品者であっても、URLを直接入力して自身の売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）
商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（画像に関しては、表示されない状態で良い）
https://i.gyazo.com/25fbea6b960dc3b305883bee603b0221.mp4